### PR TITLE
Change package.json main to use index.coffee

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "hubot-gotomeeting",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "hubot script to manage GoToMeeting meetings",
-  "main": "src/gotomeeting.coffee",
+  "main": "index.coffee",
   "scripts": {
     "test": "script/test",
     "shell": "hubot -r src"


### PR DESCRIPTION
When this package is required via external-scripts.json it goes directly to src/gotomeeting.coffee, and index.coffee is never used.  This change uses index.coffee so hubot loadFile and thus parseHelp functions are called and help commands are added to @commands.  After this change hubot-help can be used.
